### PR TITLE
avoid using multiline comment

### DIFF
--- a/bindings-portaudio.cabal
+++ b/bindings-portaudio.cabal
@@ -121,14 +121,13 @@ library
       portaudio/src/hostapi/coreaudio/pa_mac_core_utilities.c
     cc-options: -DPA_USE_COREAUDIO=1
 
-{- Unsupported
-  if flag(ASIO)
-    include-dirs:
-      portaudio/src/hostapi/asio
-    c-sources:
-      portaudio/src/hostapi/asio/pa_asio.cpp
-    cc-options: -DPA_USE_ASIO=1
--}
+-- Unsupported
+--   if flag(ASIO)
+--     include-dirs:
+--       portaudio/src/hostapi/asio
+--     c-sources:
+--       portaudio/src/hostapi/asio/pa_asio.cpp
+--     cc-options: -DPA_USE_ASIO=1
 
 source-repository head
   type:     git


### PR DESCRIPTION
Because following error reported by clang in OSX:

``` log
clang: error: no such file or directory: 'Unsupported'
clang: error: no such file or directory: 'if'
clang: error: no such file or directory: 'flag(ASIO)'
clang: error: no such file or directory: 'include-dirs:'
clang: error: no such file or directory: 'c-sources:'
clang: error: no such file or directory: 'cc-options:'
```
