### PR TITLE
avoid deplicate symbols

### DIFF
--- a/bindings-portaudio.cabal
+++ b/bindings-portaudio.cabal
@@ -131,7 +131,7 @@ library
     c-sources:
       portaudio/src/hostapi/coreaudio/pa_mac_core.c
       portaudio/src/hostapi/coreaudio/pa_mac_core_blocking.c
-      portaudio/src/hostapi/coreaudio/pa_mac_core_old.c
+      -- portaudio/src/hostapi/coreaudio/pa_mac_core_old.c
       portaudio/src/hostapi/coreaudio/pa_mac_core_utilities.c
     cc-options: -DPA_USE_COREAUDIO=1
     Frameworks:


### PR DESCRIPTION
PaMacCore_Initialize() are both defined at pa_mac_core_old.c and pa_mac_core.c.
