### PR TITLE
Build with stack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,11 @@ cabal.sandbox.config
 cabal.config
 
 # =========================
+# Stack
+# =========================
+.stack-work
+
+# =========================
 # Operating System Files
 # =========================
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,17 @@
+resolver: lts-3.11
+
+packages:
+- '.'
+- example/
+
+extra-deps: []
+
+flags:
+  bindings-portaudio:
+    wasapi: false
+    wdmks: false
+    bundle: false
+    wmme: false
+    directsound: false
+
+extra-package-dbs: []


### PR DESCRIPTION
Perhaps, it makes convenience for stack users.
But this library does not depends many libraries....
Should we provide `stack.yaml` for stack users?